### PR TITLE
pkgdef: fix case of appGrid.svg reference

### DIFF
--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -48,7 +48,7 @@ const pkgdef :Spk.PackageDefinition = (
       # https://github.com/sandstorm-io/sandstorm/blob/master/src/sandstorm/package.capnp
       icons = (
         # Various icons to represent the app in various contexts.
-        appGrid = (svg = embed "app-graphics/appgrid.svg"),
+        appGrid = (svg = embed "app-graphics/appGrid.svg"),
         grain = (svg = embed "app-graphics/grain.svg"),
         market = (svg = embed "app-graphics/market.svg"),
         marketBig = (svg = embed "app-graphics/marketBig.svg"),


### PR DESCRIPTION
This typo prevented me from executing `vagrant-spk dev`:

```
$ ../vagrant-spk/vagrant-spk dev
Calling 'vagrant' 'ssh' '-c' '/opt/app/.sandstorm/build.sh && cd /opt/app/.sandstorm && spk dev --pkg-def=/opt/app/.sandstorm/sandstorm-pkgdef.capnp:pkgdef' 
in /home/joonas/Documents/projects/sandstorm/tiddlywiki-sandstorm/.sandstorm
*** Uncaught exception ***
/opt/app/.sandstorm/sandstorm-pkgdef.capnp:50: failed: Couldn't read file for embed: app-graphics/appgrid.svg
Connection to 127.0.0.1 closed.
Traceback (most recent call last):
  File "../vagrant-spk/vagrant-spk", line 1028, in <module>
    main()
  File "../vagrant-spk/vagrant-spk", line 1025, in main
    operation(args)
  File "../vagrant-spk/vagrant-spk", line 680, in dev
    "spk dev --pkg-def=/opt/app/.sandstorm/sandstorm-pkgdef.capnp:pkgdef"
  File "../vagrant-spk/vagrant-spk", line 294, in call_vagrant_command
    return subprocess.check_call(command, cwd=sandstorm_dir)
  File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['vagrant', 'ssh', '-c', '/opt/app/.sandstorm/build.sh && cd /opt/app/.sandstorm && spk dev --pkg-def=/opt/app/.sandstorm/sandstorm-pkgdef.capnp:pkgdef']' returned non-zero exit status 1
```
